### PR TITLE
Parallel Execution - Steel Members

### DIFF
--- a/Commands/SteelBeamForces.cs
+++ b/Commands/SteelBeamForces.cs
@@ -14,6 +14,9 @@ using TSD.API.Remoting.Structure;
 using TSD.API.Remoting.Sections;
 using TeklaResultsInterrogator.Utils;
 using static TeklaResultsInterrogator.Utils.Utils;
+using System.Diagnostics.Metrics;
+using System.Xml.Linq;
+using System.Reflection.PortableExecutable;
 
 namespace TeklaResultsInterrogator.Commands
 {
@@ -26,6 +29,118 @@ namespace TeklaResultsInterrogator.Commands
             
         }
 
+        string GetMemberLevelNameAsync(IMember member)
+        {
+            int constructionPointIndex = member.MemberNodes.Value.First().Value.ConstructionPointIndex.Value;
+            IEnumerable<IConstructionPoint> constructionPoints = Model!.GetConstructionPointsAsync(new List<int>() { constructionPointIndex }).Result;
+            int planeId = constructionPoints.First().PlaneInfo.Value.Index;
+            IEnumerable<IHorizontalConstructionPlane> levels = Model.GetLevelsAsync(new List<int>() { planeId }).Result;
+            string levelName;
+            if (levels.Any())
+            {
+                levelName = levels.First().Name;
+            }
+            else
+            {
+                levelName = "Not Associated";
+            }
+            return levelName;
+        }
+        async Task<List<string>> GetMemberSpanInfoAsync(String levelName, IMember member, IMemberSpan span, int subdivisions, List<ILoadingCase> loadingCases,  Boolean reduced)
+        {
+            List<string> output = new List<string>();
+            Guid id = member.Id;
+            string name = member.Name;
+            string spanName = span.Name;
+            int spanIdx = span.Index;
+            double length = span.Length.Value;
+            double lengthFt = length * 0.00328084; // Converting from [mm] to [ft]
+            double rot = Math.Round(span.RotationAngle.Value * 57.2958, 3); // Converting from [rad] to [deg]
+            IMemberSection section = (IMemberSection)span.ElementSection.Value;
+            string sectionName = section.PhysicalSection.Value.LongName;
+            string materialGrade = span.Material.Value.Name;
+
+            int startNodeIdx = span.StartMemberNode.ConstructionPointIndex.Value;
+            string startNodeFixity = span.StartReleases.Value.DegreeOfFreedom.Value.ToString();
+            if (GetProperty(span.StartReleases.Value.Cantilever) == true)
+            {
+                startNodeFixity += " (Cantilever end)";
+            }
+            startNodeFixity = startNodeFixity.Replace(',', '|');
+            int endNodeIdx = span.EndMemberNode.ConstructionPointIndex.Value;
+            string endNodeFixity = span.EndReleases.Value.DegreeOfFreedom.Value.ToString();
+            if (GetProperty(span.EndReleases.Value.Cantilever) == true)
+            {
+                endNodeFixity += " (Cantilever end)";
+            }
+            endNodeFixity = endNodeFixity.Replace(',', '|');
+
+            string spanLineOnly = String.Format("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10},{11}",
+                id, name, levelName, sectionName, materialGrade, spanName,
+                startNodeIdx, startNodeFixity, endNodeIdx, endNodeFixity, lengthFt, rot);
+
+            if (subdivisions == 0)
+            {
+                output.Add(spanLineOnly);
+            }
+
+            else
+            {
+                List<Task<MaxSpanInfo>> maxSpanInfotasks = new List<Task<MaxSpanInfo>>();
+                List<Task<List<PointSpanInfo>>> pointSpanInfotasks = new List<Task<List<PointSpanInfo>>>();
+
+                foreach (ILoadingCase loadingCase in loadingCases)
+                {
+                    string loadName = loadingCase.Name.Replace(',', '`');
+                    SpanResults spanResults = new SpanResults(span, subdivisions, loadingCase, reduced, AnalysisType, member);
+
+                    if (subdivisions >= 1)
+                    {
+                        // Getting maximum internal forces and displacements and locations in parallel
+                        maxSpanInfotasks.Add(Task.Run(() => spanResults.GetMaxima()));
+                    }
+
+                    if (subdivisions >= 2)
+                    {
+                        // Getting internal forces and displacements at each station in parallel
+                        pointSpanInfotasks.Add(Task.Run(() => spanResults.GetStations()));
+                    }
+                }
+                // Wait for all maxSpanInfo tasks to finish
+                MaxSpanInfo[] completedMaxSpanTasks = await Task.WhenAll(maxSpanInfotasks); //execute in parallel
+                // Wait for all pointSpanInfo tasks to finish
+                List<PointSpanInfo>[] completedPointSpanInfoTasks = await Task.WhenAll(pointSpanInfotasks); //execute in parallel
+
+                //Process MaxSpanInfo results
+                foreach (MaxSpanInfo task in completedMaxSpanTasks)
+                {
+                    MaxSpanInfo maxSpanInfo = task;
+                    string maxLine = spanLineOnly + "," + String.Format("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9}",
+                           maxSpanInfo.LoadName, "MAXIMA",
+                           maxSpanInfo.ShearMajor.Value,
+                           maxSpanInfo.ShearMinor.Value,
+                           maxSpanInfo.MomentMajor.Value,
+                           maxSpanInfo.MomentMinor.Value,
+                           maxSpanInfo.AxialForce.Value,
+                           maxSpanInfo.Torsion.Value,
+                           maxSpanInfo.DeflectionMajor.Value,
+                           maxSpanInfo.DeflectionMinor.Value);
+                    output.Add(maxLine);
+                }
+                //Process MaxSpanInfo results
+                foreach (List<PointSpanInfo> pointSpanInfoList in completedPointSpanInfoTasks)
+                {
+                    foreach (PointSpanInfo info in pointSpanInfoList)
+                    {
+                        string posLine = spanLineOnly + "," + String.Format("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9}",
+                                            info.LoadName, info.Position, info.ShearMajor, info.ShearMinor, info.MomentMajor, info.MomentMinor,
+                                            info.AxialForce, info.Torsion, info.DeflectionMajor, info.DeflectionMinor);
+                        output.Add(posLine);
+                    }   
+                }
+            }
+            return output;
+        }
         public override async Task ExecuteAsync()
         {
             // Initialize parents
@@ -44,9 +159,9 @@ namespace TeklaResultsInterrogator.Commands
             // Unpacking loading data
             FancyWriteLine("Loading Summary:", TextColor.Title);
             Console.WriteLine("Unpacking loading data...");
-            Console.WriteLine($"{AllLoadcases.Count} loadcases found, {SolvedCases.Count} solved.");
-            Console.WriteLine($"{AllCombinations.Count} load combinations found, {SolvedCombinations.Count} solved.");
-            Console.WriteLine($"{AllEnvelopes.Count} load envelopes found, {SolvedEnvelopes.Count} solved.\n");
+            Console.WriteLine($"{AllLoadcases!.Count} loadcases found, {SolvedCases!.Count} solved.");
+            Console.WriteLine($"{AllCombinations!.Count} load combinations found, {SolvedCombinations!.Count} solved.");
+            Console.WriteLine($"{AllEnvelopes!.Count} load envelopes found, {SolvedEnvelopes!.Count} solved.\n");
 
             stopwatch.Stop();
             List<ILoadingCase> loadingCases = AskLoading(SolvedCases, SolvedCombinations, SolvedEnvelopes);
@@ -57,9 +172,9 @@ namespace TeklaResultsInterrogator.Commands
             FancyWriteLine("\nMember summary:", TextColor.Title);
             Console.WriteLine("Unpacking member data...");
             
-            List<IMember> steelBeams = AllMembers.Where(c => RequestedMemberType.Contains(GetProperty(c.Data.Value.Construction))).ToList();
+            List<IMember> steelBeams = AllMembers!.Where(c => RequestedMemberType.Contains(GetProperty(c.Data.Value.Construction))).ToList();
 
-            Console.WriteLine($"{AllMembers.Count} structural members found in model.");
+            Console.WriteLine($"{AllMembers!.Count} structural members found in model.");
             Console.WriteLine($"{steelBeams.Count} steel beams found.");
 
             double timeUnpack = Math.Round(stopwatch.Elapsed.TotalSeconds, 3);
@@ -85,106 +200,28 @@ namespace TeklaResultsInterrogator.Commands
             File.WriteAllText(file1, "");
             File.AppendAllText(file1, header1);
 
-
+            List<string>[] completedTaskOutput;
+            List<Task<List<string>>> tasks = new();
+            foreach (IMember member in steelBeams)
+            {
+                string levelName = GetMemberLevelNameAsync(member);
+                IEnumerable<IMemberSpan> spans = await member.GetSpanAsync(); //should not be long running so await 
+                foreach (IMemberSpan span in spans)
+                {
+                    tasks.Add(Task.Run(() => GetMemberSpanInfoAsync(levelName, member, span, subdivisions, loadingCases, reduced)));
+                } 
+            }
+            completedTaskOutput = await Task.WhenAll(tasks); //execute in parallel
             // Getting internal forces and writing table
             FancyWriteLine("\nWriting internal forces table...", TextColor.Title);
             using (StreamWriter sw1 = new StreamWriter(file1, true, Encoding.UTF8, bufferSize))
             {
-                foreach (IMember member in steelBeams)
+                //process output to streamwriter
+                foreach (List<string> outputLines in completedTaskOutput)
                 {
-                    string name = member.Name;
-                    Guid id = member.Id;
-                    IEnumerable<IMemberSpan> spans = await member.GetSpanAsync();
-
-                    int constructionPointIndex = member.MemberNodes.Value.First().Value.ConstructionPointIndex.Value;
-                    IEnumerable<IConstructionPoint> constructionPoints = await Model.GetConstructionPointsAsync(new List<int>() { constructionPointIndex });
-                    int planeId = constructionPoints.First().PlaneInfo.Value.Index;
-                    IEnumerable<IHorizontalConstructionPlane> level = await Model.GetLevelsAsync(new List<int>() { planeId });
-                    string levelName;
-                    if (level.Any())
+                    foreach (string outputLine in outputLines)
                     {
-                        levelName = level.First().Name;
-                    }
-                    else
-                    {
-                        levelName = "Not Associated";
-                    }
-                    
-
-
-                    foreach (IMemberSpan span in spans)
-                    {
-                        string spanName = span.Name;
-                        int spanIdx = span.Index;
-                        double length = span.Length.Value;
-                        double lengthFt = length * 0.00328084; // Converting from [mm] to [ft]
-                        double rot = Math.Round(span.RotationAngle.Value * 57.2958, 3); // Converting from [rad] to [deg]
-                        IMemberSection section = (IMemberSection)span.ElementSection.Value;
-                        string sectionName = section.PhysicalSection.Value.LongName;
-                        string materialGrade = span.Material.Value.Name;
-
-                        int startNodeIdx = span.StartMemberNode.ConstructionPointIndex.Value;
-                        string startNodeFixity = span.StartReleases.Value.DegreeOfFreedom.Value.ToString();
-                        if (GetProperty(span.StartReleases.Value.Cantilever) == true)
-                        {
-                            startNodeFixity += " (Cantilever end)";
-                        }
-                        startNodeFixity = startNodeFixity.Replace(',', '|');
-                        int endNodeIdx = span.EndMemberNode.ConstructionPointIndex.Value;
-                        string endNodeFixity = span.EndReleases.Value.DegreeOfFreedom.Value.ToString();
-                        if (GetProperty(span.EndReleases.Value.Cantilever) == true)
-                        {
-                            endNodeFixity += " (Cantilever end)";
-                        }
-                        endNodeFixity = endNodeFixity.Replace(',', '|');
-
-                        string spanLineOnly = String.Format("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10},{11}",
-                            id, name, levelName, sectionName, materialGrade, spanName,
-                            startNodeIdx, startNodeFixity, endNodeIdx, endNodeFixity, lengthFt, rot);
-
-                        if (subdivisions == 0)
-                        {
-                            sw1.WriteLine(spanLineOnly);
-                        }
-
-                        else
-                        {
-                            foreach (ILoadingCase loadingCase in loadingCases)
-                            {
-                                string loadName = loadingCase.Name.Replace(',', '`');
-                                SpanResults spanResults = new SpanResults(span, subdivisions, loadingCase, reduced, AnalysisType, member);
-
-                                if (subdivisions >= 1)
-                                {
-                                    // Getting maximum internal forces and displacements and locations
-                                    MaxSpanInfo maxSpanInfo = await spanResults.GetMaxima();
-                                    string maxLine = spanLineOnly + "," + String.Format("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9}",
-                                        loadName, "MAXIMA",
-                                        maxSpanInfo.ShearMajor.Value,
-                                        maxSpanInfo.ShearMinor.Value,
-                                        maxSpanInfo.MomentMajor.Value,
-                                        maxSpanInfo.MomentMinor.Value,
-                                        maxSpanInfo.AxialForce.Value,
-                                        maxSpanInfo.Torsion.Value,
-                                        maxSpanInfo.DeflectionMajor.Value,
-                                        maxSpanInfo.DeflectionMinor.Value);
-                                    sw1.WriteLine(maxLine);
-                                }
-
-                                if (subdivisions >= 2)
-                                {
-                                    // Getting internal forces and displacements at each station
-                                    List<PointSpanInfo> pointSpanInfo = await spanResults.GetStations();
-                                    foreach (PointSpanInfo info in pointSpanInfo)
-                                    {
-                                        string posLine = spanLineOnly + "," + String.Format("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9}",
-                                        loadName, info.Position, info.ShearMajor, info.ShearMinor, info.MomentMajor, info.MomentMinor,
-                                        info.AxialForce, info.Torsion, info.DeflectionMajor, info.DeflectionMinor);
-                                        sw1.WriteLine(posLine);
-                                    }
-                                }
-                            }
-                        }
+                        sw1.WriteLine(outputLine);
                     }
                 }
             }

--- a/Commands/TimberColumnForces.cs
+++ b/Commands/TimberColumnForces.cs
@@ -43,9 +43,9 @@ namespace TeklaResultsInterrogator.Commands
             // Unpacking loading data
             FancyWriteLine("Loading Summary:", TextColor.Title);
             Console.WriteLine("Unpacking loading data...");
-            Console.WriteLine($"{AllLoadcases.Count} loadcases found, {SolvedCases.Count} solved.");
-            Console.WriteLine($"{AllCombinations.Count} load combinations found, {SolvedCombinations.Count} solved.");
-            Console.WriteLine($"{AllEnvelopes.Count} load envelopes found, {SolvedEnvelopes.Count} solved.\n");
+            Console.WriteLine($"{AllLoadcases!.Count} loadcases found, {SolvedCases!.Count} solved.");
+            Console.WriteLine($"{AllCombinations!.Count} load combinations found, {SolvedCombinations!.Count} solved.");
+            Console.WriteLine($"{AllEnvelopes!.Count} load envelopes found, {SolvedEnvelopes!.Count} solved.\n");
 
             stopwatch.Stop();
             List<ILoadingCase> loadingCases = AskLoading(SolvedCases, SolvedCombinations, SolvedEnvelopes);
@@ -56,12 +56,12 @@ namespace TeklaResultsInterrogator.Commands
             FancyWriteLine("\nMember summary:", TextColor.Title);
             Console.WriteLine("Unpacking member data...");
 
-            List<IMember> timberColumns = AllMembers.Where(c => RequestedMemberType.Contains(c.Data.Value.Construction.Value)).ToList();
+            List<IMember> timberColumns = AllMembers!.Where(c => RequestedMemberType.Contains(c.Data.Value.Construction.Value)).ToList();
 
-            Console.WriteLine($"{AllMembers.Count} structural members found in model.");
+            Console.WriteLine($"{AllMembers!.Count} structural members found in model.");
             Console.WriteLine($"{timberColumns.Count} timber columns found.");
 
-            List<IHorizontalConstructionPlane> levels = (await Model.GetLevelsAsync()).ToList();
+            List<IHorizontalConstructionPlane> levels = (await Model!.GetLevelsAsync()).ToList();
 
             double timeUnpack = Math.Round(stopwatch.Elapsed.TotalSeconds, 3);
             Console.WriteLine($"Loading and member data unpacked in {timeUnpack} seconds.\n");
@@ -152,8 +152,8 @@ namespace TeklaResultsInterrogator.Commands
 
                         foreach (ILoadingCase loadingCase in loadingCases)
                         {
-                            string loadName = loadingCase.Name.Replace(',', '`');
-                            MaxSpanInfo maxLiftInfo = new MaxSpanInfo();
+                            //string loadName = loadingCase.Name.Replace(',', '`');
+                            MaxSpanInfo maxLiftInfo = new MaxSpanInfo(loadingCase);
 
                             foreach (IMemberSpan span in lift.Values)
                             {
@@ -163,7 +163,7 @@ namespace TeklaResultsInterrogator.Commands
                             }
 
                             string maxLine = liftLineOnly + "," + String.Format("{0},{1},{2},{3},{4},{5},{6}",
-                                loadName,
+                                maxLiftInfo.LoadName,
                                 maxLiftInfo.ShearMajor.Value,
                                 maxLiftInfo.ShearMinor.Value,
                                 maxLiftInfo.MomentMajor.Value,

--- a/Core/ForceInterrogator.cs
+++ b/Core/ForceInterrogator.cs
@@ -19,14 +19,14 @@ namespace TeklaResultsInterrogator.Core
         protected AnalysisType AnalysisType = AnalysisType.FirstOrderLinear;
 
         protected List<MemberConstruction> RequestedMemberType = new List<MemberConstruction>();
-        protected TSD.API.Remoting.Solver.IModel? SolverModel { get; set; }
-        protected List<ILoadcase>? AllLoadcases { get; set; }
-        protected List<ILoadcase>? SolvedCases { get; set; }
-        protected List<ICombination>? AllCombinations { get; set; }
-        protected List<ICombination>? SolvedCombinations { get; set; }
-        protected List<IEnvelope>? AllEnvelopes { get; set; }
-        protected List<IEnvelope>? SolvedEnvelopes { get; set; }
-        protected List<IMember>? AllMembers { get; set; }
+        protected TSD.API.Remoting.Solver.IModel? SolverModel { get; private set; }
+        protected List<ILoadcase>? AllLoadcases { get; private set; }
+        protected List<ILoadcase>? SolvedCases { get; private set; }
+        protected List<ICombination>? AllCombinations { get; private set; }
+        protected List<ICombination>? SolvedCombinations { get; private set; }
+        protected List<IEnvelope>? AllEnvelopes { get; private set; }
+        protected List<IEnvelope>? SolvedEnvelopes { get; private set; }
+        protected List<IMember>? AllMembers { get; private set; }
         public ForceInterrogator() { }
 
         public override async Task InitializeAsync()  // to get solver model and other stuff here
@@ -90,7 +90,7 @@ namespace TeklaResultsInterrogator.Core
             // Get members
             Console.WriteLine("Searching for members...");
             IEnumerable<IMember>? allMembers = await Model.GetMembersAsync(null);
-            if (!allMembers.Any() || allMembers == null)
+            if (allMembers == null || !allMembers.Any())
             {
                 FancyWriteLine("No members found!", TextColor.Error);
                 Flag = true;
@@ -182,15 +182,15 @@ namespace TeklaResultsInterrogator.Core
 
             if (solvedCases.Count > 0)
             {
-                loadingOptions.Add("Loadcases", solvedCases.Cast<ILoadingCase>().ToList());
+                loadingOptions.Add("LOADCASES", solvedCases.Cast<ILoadingCase>().ToList());
             }
             if (solvedCombinations.Count > 0)
             {
-                loadingOptions.Add("Combinations", solvedCombinations.Cast<ILoadingCase>().ToList());
+                loadingOptions.Add("COMBINATIONS", solvedCombinations.Cast<ILoadingCase>().ToList());
             }
             if (solvedEnvelopes.Count > 0)
             {
-                loadingOptions.Add("Envelopes", solvedEnvelopes.Cast<ILoadingCase>().ToList());
+                loadingOptions.Add("ENVELOPES", solvedEnvelopes.Cast<ILoadingCase>().ToList());
             }
 
             List<ILoadingCase>? loadingCases = null;

--- a/Core/MaxSpanInfo.cs
+++ b/Core/MaxSpanInfo.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TSD.API.Remoting.Loading;
 
 namespace TeklaResultsInterrogator.Core
 {
     public class MaxSpanInfo
     {
+        public string LoadName { get;}
         public MaxSpanInfoData ShearMajor { get; set; }
         public MaxSpanInfoData ShearMinor { get; set; }
         public MaxSpanInfoData MomentMajor { get; set; }
@@ -19,8 +21,9 @@ namespace TeklaResultsInterrogator.Core
         public MaxSpanInfoData DisplacementMajor { get; set; }
         public MaxSpanInfoData DisplacementMinor { get; set; }
 
-        public MaxSpanInfo(MaxSpanInfoData shearMajor, MaxSpanInfoData shearMinor, MaxSpanInfoData momentMajor, MaxSpanInfoData momentMinor, MaxSpanInfoData axialForce, MaxSpanInfoData torsion, MaxSpanInfoData deflectionMajor, MaxSpanInfoData deflectionMinor, MaxSpanInfoData displacementMajor, MaxSpanInfoData displacementMinor)
+        public MaxSpanInfo(ILoadingCase loadingCase, MaxSpanInfoData shearMajor, MaxSpanInfoData shearMinor, MaxSpanInfoData momentMajor, MaxSpanInfoData momentMinor, MaxSpanInfoData axialForce, MaxSpanInfoData torsion, MaxSpanInfoData deflectionMajor, MaxSpanInfoData deflectionMinor, MaxSpanInfoData displacementMajor, MaxSpanInfoData displacementMinor)
         {
+            LoadName = loadingCase.Name.Replace(',', '`');
             ShearMajor = shearMajor;
             ShearMinor = shearMinor;
             MomentMajor = momentMajor;
@@ -33,8 +36,9 @@ namespace TeklaResultsInterrogator.Core
             DisplacementMinor = displacementMinor;
         }
 
-        public MaxSpanInfo()
+        public MaxSpanInfo(ILoadingCase loadingCase)
         {
+            LoadName = loadingCase.Name.Replace(',', '`');
             ShearMajor = new MaxSpanInfoData();
             ShearMinor = new MaxSpanInfoData();
             MomentMajor = new MaxSpanInfoData();

--- a/Core/PointSpanInfo.cs
+++ b/Core/PointSpanInfo.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TSD.API.Remoting.Loading;
 
 namespace TeklaResultsInterrogator.Core
 {
     public class PointSpanInfo
     {
+        public string LoadName { get; }
         public double Position { get; set; }
         public double ShearMajor { get; set; }
         public double ShearMinor { get; set; }
@@ -20,8 +22,9 @@ namespace TeklaResultsInterrogator.Core
         public double DisplacementMajor { get; set; }
         public double DisplacementMinor { get; set; }
 
-        public PointSpanInfo(double position, double shearMajor, double shearMinor, double momentMajor, double momentMinor, double axialForce, double torsion, double deflectionMajor, double deflectionMinor, double displacementMajor, double displacementMinor)
+        public PointSpanInfo(ILoadingCase loadingCase, double position, double shearMajor, double shearMinor, double momentMajor, double momentMinor, double axialForce, double torsion, double deflectionMajor, double deflectionMinor, double displacementMajor, double displacementMinor)
         {
+            LoadName = loadingCase.Name.Replace(',', '`');
             Position = position;
             ShearMajor = shearMajor;
             ShearMinor = shearMinor;

--- a/Core/SpanResults.cs
+++ b/Core/SpanResults.cs
@@ -80,7 +80,7 @@ namespace TeklaResultsInterrogator.Core
             MaxSpanInfoData displacementMinor = await CalculateMaximum(memberLoading, DisplacementMinorValueOption);
 
             // Instantiate and return MaxSpanInfo object
-            return new MaxSpanInfo(shearMajor, shearMinor, momentMajor, momentMinor, axialForce, torsion, deflectionMajor, deflectionMinor, displacementMajor, displacementMinor);
+            return new MaxSpanInfo(Loading, shearMajor, shearMinor, momentMajor, momentMinor, axialForce, torsion, deflectionMajor, deflectionMinor, displacementMajor, displacementMinor);
         }
 
         private async Task<MaxSpanInfoData> CalculateMaximum(IMemberLoading loading, LoadingValueOptions option)
@@ -149,7 +149,7 @@ namespace TeklaResultsInterrogator.Core
                 double displacementMinor = await GetLoadingValues(memberLoading, DisplacementMinorValueOption, position);
 
                 double positionFt = position * 0.00328084; // Converting from [mm] to [ft]
-                PointSpanInfo stationInfo = new PointSpanInfo(positionFt, shearMajor, shearMinor, momentMajor, momentMinor, axialForce, torsion, deflectionMajor, deflectionMinor, displacementMajor, displacementMinor);
+                PointSpanInfo stationInfo = new PointSpanInfo(Loading, positionFt, shearMajor, shearMinor, momentMajor, momentMinor, axialForce, torsion, deflectionMajor, deflectionMinor, displacementMajor, displacementMinor);
 
                 stationData.Add(stationInfo);
             }

--- a/Program.cs
+++ b/Program.cs
@@ -64,7 +64,7 @@ namespace TeklaResultsInterrogator
         private static void HaltExit(bool success)
         {
             string name = Process.GetCurrentProcess().ProcessName;
-            string path = Environment.ProcessPath;
+            string? path = Environment.ProcessPath;
             int process = Process.GetCurrentProcess().Id;
             string status = (success == true) ? "successfully" : "unsuccessfully";
             Console.WriteLine($"\n{name} at {path} (process {process}) executed {status}.");

--- a/TeklaResultsInterrogator.csproj
+++ b/TeklaResultsInterrogator.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="TeklaStructuralDesigner.RemotingAPI" Version="23.2.0" />
+    <PackageReference Include="TeklaStructuralDesigner.RemotingAPI" Version="24.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Utils/AskUser.cs
+++ b/Utils/AskUser.cs
@@ -14,7 +14,14 @@ namespace TeklaResultsInterrogator.Utils
             Console.ForegroundColor = (ConsoleColor)TextColor.Command;
             string? readIn = Console.ReadLine();
             Console.ForegroundColor = (ConsoleColor)TextColor.Text;
-            return readIn;
+            if (readIn == null || readIn.Length == 0)
+            {
+                return readIn;
+            }
+            else
+            {
+                return readIn.ToUpper();
+            }
         }
     }
 }


### PR DESCRIPTION
- Implemented parallel execution for steel members with significant improvements in execution time. TODO: generalize into base class
- Added null-forgiving operator where null checks previously exist in base class to remove compiler warnings
- Created read-only properties in the `ForceInterrogator` base class
- Broke out GetMemberLevelNameAsync into a separate function call. TODO: generalize into base class
- Started to implement non-case sensitive commands. This currently only works on y/n questions and load case/combo options. TODO: number load case and combo options so the user can type a number versus the entire case/combo name.
